### PR TITLE
Usar el crédito establecido por el usuario

### DIFF
--- a/photostore/models/security.py
+++ b/photostore/models/security.py
@@ -103,6 +103,9 @@ class User(UserMixin, db.Model):
     def check_password_hash(self, password):
         return check_password_hash(self.password_hash, password)
 
+    def getCreditLine(self):
+        return self.credit_line or self.name or self.username
+
     def __repr__(self):
         return '<User {}>'.format(self.email or self.username)
 

--- a/photostore/store/templates/store/upload.html
+++ b/photostore/store/templates/store/upload.html
@@ -32,14 +32,15 @@
                 </div>
                 <div class="row">
                     <div class="input-field col s6">
-                        <input data-newcov-target="creditline" type="text" name="creditline" id="creditline_field" class="validate" value="Foto de {{ current_user.name }}" required>
+                        <input data-newcov-target="creditline" type="text" name="creditline" id="creditline_field" class="validate" value="Foto de {{ current_user.getCreditLine() }}" required>
                         <label for="creditline_field">Creditos</label>
                     </div>
                     <div class="input-field col s6">
                         <input data-newcov-target="takenby" type="text" name class="validate" name="taken_by" id="taken_by_field" value="" required />
                         <label for="creditline_field">Author</label>
                         <span class="helper-text">
-                            Si se establece reemplaza los datos en la foto.
+                            Si se establece reemplaza los datos en la foto. <strong>No es, ni tiene porque ser igual a
+                            los creditos</strong>.
                         </span>
                     </div>
                 </div>

--- a/photostore/store/views.py
+++ b/photostore/store/views.py
@@ -247,8 +247,6 @@ def buscar_indice():
     qp = MultifieldParser([
         "headline", "excerpt", "credit_line",
         "taken_by", "keywords"], ix.schema)
-    photos = []
-    keywords_grp = {}
     with ix.searcher() as s:
         results = PhotoPaginaBusqueda(s.search_page(
             qp.parse(userquery), page, pagelen=9,  groupedby="keywords"))


### PR DESCRIPTION
Al crear una nueva cobertura usar el credito establecido por el usuario
en su perfil.

Closes #43